### PR TITLE
Fix Examples (particularly canvas)

### DIFF
--- a/src/rita.js
+++ b/src/rita.js
@@ -1368,7 +1368,7 @@
 				// alias' for RiTa-java static functions  (?)
 				RiText.setDefaultFont = RiText.defaultFont; 
 				RiText.setDefaultColor = RiText.defaultColor;
-				//RiText.setDefaultAlignment = RiText.defaultAlignment;
+				RiText.setDefaultAlignment = RiText.defaultAlignment;
 				RiText.setCallbackTimer = RiText.timer;
 				
 				if (typeof window != 'undefined' && window && !hasProcessing) { // remove all this?
@@ -1391,7 +1391,7 @@
 				
 				delete RiText.setDefaultFont;
 				delete RiText.setDefaultColor;
-				//delete RiText.setDefaultAlignment;
+				delete RiText.setDefaultAlignment;
 				delete RiText.setCallbackTimer;
 
 				if (typeof window != 'undefined' && window && !hasProcessing)  {
@@ -5043,13 +5043,13 @@
 	 * Sets/gets the default alignment for all RiTexts
 	 * @param {number} align (optional, for sets only)
 	 * @returns {number} the current default alignment
-
+    */
 	RiText.defaultAlignment = function(align) {
 
 		if (arguments.length==1)
 			RiText.defaults.alignment = align;
 		return RiText.defaults.alignment;
-	}	 */
+	}
 	
 	/**
 	 * Sets/gets the default font size for all RiTexts
@@ -5134,15 +5134,31 @@
 	 * @param {number} a (optional)
 	 * @returns {object} the current default color
 	 */
-	RiText.defaultColor = function(r, g, b, a) {
- 
-		if (arguments.length) { 
-			RiText.defaults.color = parseColor.apply(this,arguments);
-		}
-		return RiText.defaults.color;
-	}
+  RiText.defaultColor = function(r, g, b, a) {
+
+    if (arguments.length) {
+      RiText.defaults.color = parseColor.apply(this,arguments);
+    }
+    return RiText.defaults.color;
+  }
 	
-	
+  /**
+	 * Set/gets default boundingbox visibility
+	 *
+	 * @param {boolean} trueOrFalse (optional) true or false
+	 * @returns {object | boolean} this RiText (set) or the current boolean value (get)
+	 */
+  RiText.showBoundingBox = function(trueOrFalse) {
+
+    if (arguments.length == 1) {
+      RiText.defaults.boundingBoxVisible = trueOrFalse;
+      return this;
+    }
+
+    return RiText.defaults.boundingBoxVisible;
+  }
+
+
 	// private statics ///////////////////////////////////////////////////////////////
 	
 	RiText._layoutArray = function(lines, x, y, w, h, pfont, leading) {
@@ -6113,7 +6129,24 @@
 			
 			return id;
 		},
-	   
+    /**
+     * Sets/gets color for this RiText
+     * @param {number | array} r takes 1-4 number values for rgba, or an array of size 1-4
+	   * @param {number} g (optional)
+	   * @param {number} b (optional)
+	   * @param {number} a (optional)
+	   * @returns {object} the current color (get) or the RiText object (set)
+	   */
+    color : function(r, g, b, a) {
+
+      if (0 == arguments.length) {
+        return this._color;
+      }
+      else {
+        this._color = parseColor.apply(this,arguments);
+        return this;
+      }
+    },
 		/**
 		 * Move to new x,y position over 'seconds'
 		 * <p>
@@ -6850,10 +6883,12 @@
 		 * @returns {object | boolean}this RiText (set) or the current boolean value (get)
 		 */
 		showBoundingBox : function(trueOrFalse) {
+
 		   if (arguments.length == 1) {
 			   this._boundingBoxVisible = trueOrFalse;
 			   return this;
 		   }
+		   
 		   return this._boundingBoxVisible;
 		},
 

--- a/src/rita.js
+++ b/src/rita.js
@@ -4483,9 +4483,9 @@
 					var post = prod.substring(idx + name.length);
 					
 					if (trimSpace) {
-						pre = pre.trim();
-						expanded = expanded.trim();
-						post = post.trim();
+						pre = (pre || "").trim();
+						expanded = (expanded || "").trim();
+						post = (post || "").trim();
 					}
 
 					if (dbug) log("  pre=" + pre+"  expanded=" + expanded+"  post=" + post+"  result=" + pre + expanded + post);

--- a/www/example/canvas/alignments.html
+++ b/www/example/canvas/alignments.html
@@ -7,18 +7,18 @@
 
 RiTa.p5Compatible(true);
 
-size(400, 400);
+RiText.size(400, 400);
 
-RiText.showBoundingBoxes(true);
+RiText.showBoundingBox(true);
 RiText.defaultFont(createFont("Times", 64));
 
 RiText("Left",   200, 100).align(LEFT);
 RiText("Center", 200, 200).align(CENTER);
 RiText("Right",  200, 300).align(RIGHT);
 
-background(255);
+RiText.background(255);
 
-line(200,0,200,400);
+RiText.line(200,0,200,400);
     
 RiText.drawAll();
 

--- a/www/example/canvas/fade-to-text.html
+++ b/www/example/canvas/fade-to-text.html
@@ -29,7 +29,7 @@ function mouseClicked()
 
 function onRiTaEvent(e) { 
 
-	console.log("event-type: " + e.getType());
+	console.log("event-type: " + e.type());
 }
 
 </script>

--- a/www/example/canvas/grammar-haiku.html
+++ b/www/example/canvas/grammar-haiku.html
@@ -17,12 +17,14 @@ haikuGrammar = {
 
 var grammar, rts = [];
 
+window.onload = function() {setup(); draw();};
+
 function setup()
 {
     RiText.size(650, 200);
 
     RiText.defaultFont("arial",30);  
-    RiText.prototype.textAlign(CENTER);
+    RiText.defaultAlignment(CENTER);
 
     rts[0] = new RiText("click to", RiText.width() / 2, 75);
     rts[1] = new RiText("generate", RiText.width() / 2, 110);
@@ -47,7 +49,5 @@ function mouseClicked()
     }
     draw();
 }
-
-setup(); draw();
 
 </script>

--- a/www/example/canvas/grammar-haiku.html
+++ b/www/example/canvas/grammar-haiku.html
@@ -22,7 +22,7 @@ function setup()
     RiText.size(650, 200);
 
     RiText.defaultFont("arial",30);  
-    RiText.defaultAlignment(CENTER);
+    RiText.prototype.textAlign(CENTER);
 
     rts[0] = new RiText("click to", RiText.width() / 2, 75);
     rts[1] = new RiText("generate", RiText.width() / 2, 110);
@@ -43,9 +43,11 @@ function mouseClicked()
     var result = grammar.expand();
     var lines =  result.split("%");
     for ( var int = 0; int < rts.length; int++) {
-        rts[int].setText(lines[int]);
+        rts[int].text(lines[int]);
     }
+    draw();
 }
 
+setup(); draw();
 
 </script>

--- a/www/example/canvas/letter-grid.html
+++ b/www/example/canvas/letter-grid.html
@@ -5,12 +5,14 @@
 
 //RiTa.p5Compatible(true);
 
+window.onload = function() {setup(); draw();}
+
 function setup()
 {	
-  size(200, 200);
+  RiText.size(200, 200);
   
   RiText.defaultColor(255);
-  RiText.defaultAlignment(CENTER);
+  RiText.defaultAlignment(RiTa.CENTER);
   RiText.defaultFont("Arial",36);
 
   var rt = [];  
@@ -24,11 +26,11 @@ function setup()
       if (k < 26) {    
           
           if ("AEIOU".indexOf(c) >= 0) {  // vowels
-            rt[k].fadeColor([204], 1);
+            rt[k].colorTo([204], 1);
           }
       } 
       else {
-          rt[k].setText(k+22);  // numbers
+          rt[k].text(k+22);  // numbers
           rt[k].fill(153);
       } 
     }
@@ -43,6 +45,6 @@ function draw() {
 
 function onRiTaEvent(re) {
         
-  re.source().colorTo([ random(100,255), random(100,255), 0 ], 1);
+  re.source().colorTo([ RiTa.random(100,255), RiTa.random(100,255), 0 ], 1);
 }
 </script>

--- a/www/example/canvas/move-to.html
+++ b/www/example/canvas/move-to.html
@@ -30,7 +30,7 @@ function draw()
 //called by RiTa whenever a 'moveTo' behavior finishes
 function onRiTaEvent(e)
 {
-    if (e.getType() == 'moveToCompleted') 
+    if (e.type() == 'moveToCompleted') 
         moveToRandom(e.source());
 }
 

--- a/www/example/canvas/typewriter.html
+++ b/www/example/canvas/typewriter.html
@@ -3,13 +3,15 @@
 
 
 var rt, idx=0, tid, y = 30, s = "This is a typewriter typing a line.",
-	bell = new Audio("../data/bell.wav"), key = new Audio("../data/key.wav"); 
+	bell = new Audio("../bell.wav"), key = new Audio("../key.wav"); 
 
 RiTa.p5Compatible(true);
 
+window.onload= function(){setup();draw();}
+
 function setup() 
 { 
-  size(550,550);
+  RiText.size(550,550);
 
   RiText.defaultFont("courier", 24);
   rt = new RiText("", 20, y);
@@ -30,11 +32,13 @@ function onRiTaEvent(re) {
     idx = 0;
   }   
   else if (!rt.endsWith(" ")) 
-    key.play();    
+    key.play();
+
+  draw();
 }
 
 function draw() {
-  background(255);
+  RiText.background(255);
   RiText.drawAll();
 }
 

--- a/www/example/canvas/words-letters-lines.html
+++ b/www/example/canvas/words-letters-lines.html
@@ -15,7 +15,7 @@ function setup()
 {
   RiText.defaultFont( { name:"Georgia", size:32 });
   
-  RiText.showBoundingBoxes(true);
+  RiText.showBoundingBox(true);
 
   line1 = new RiText(txt, 64, 100);     // lines
   

--- a/www/example/processing/grammar-haiku.html
+++ b/www/example/processing/grammar-haiku.html
@@ -19,8 +19,8 @@ void setup()
 {
     size(650, 200);
 
-    RiText.setDefaultFont(createFont("arial",30));  
-    RiText.setDefaultAlignment(CENTER);
+    // RiText.setDefaultFont(createFont("arial",30));  
+    // RiText.setDefaultAlignment(CENTER);
 
     rts[0] = new RiText("click to", width / 2, 75);
     rts[1] = new RiText("generate", width / 2, 110);
@@ -42,7 +42,7 @@ void mouseClicked()
     var result = grammar.expand();
     var lines =  result.split("%");
     for ( var int = 0; int < rts.length; int++) {
-        rts[int].setText(lines[int]);
+        rts[int].text(lines[int]);
     }
 }
 

--- a/www/example/processing/grammar-haiku.html
+++ b/www/example/processing/grammar-haiku.html
@@ -2,6 +2,8 @@
 <script src="../../../src/rita.js"></script>
 <script type="text/processing" data-processing-target="mycanvas">
 
+RiTa.p5Compatible(1);
+
 haikuGrammar = { 
     "<start>": "<5-line> % <7-line> % <5-line>",  
     "<5-line>": "<1> <4> |<1> <3> <1> |<1> <1> <3> | <1> <2> <2> | <1> <2> <1> <1> | <1> <1> <2> <1> | <1> <1> <1> <2> | <1> <1> <1> <1> <1> | <2> <3> | <2> <2> <1> | <2> <1> <2> | <2> <1> <1> <1> | <3> <2> | <3> <1> <1> | <4> <1> | <5>",
@@ -19,8 +21,8 @@ void setup()
 {
     size(650, 200);
 
-    // RiText.setDefaultFont(createFont("arial",30));  
-    // RiText.setDefaultAlignment(CENTER);
+    RiText.setDefaultFont(createFont("arial",30));  
+    RiText.setDefaultAlignment(CENTER);
 
     rts[0] = new RiText("click to", width / 2, 75);
     rts[1] = new RiText("generate", width / 2, 110);

--- a/www/example/processing/typewriter.html
+++ b/www/example/processing/typewriter.html
@@ -6,7 +6,7 @@
 RiText rt;
 int idx, tid, y = 30;	
 String s = "This is a typewriter typing a line.";
-bell = new Audio("../data/bell.wav"), key = new Audio("../data/key.wav"); 
+bell = new Audio("../bell.wav"), key = new Audio("../key.wav"); 
 
 void setup() 
 { 


### PR DESCRIPTION
`/src/rita.js`:
- Re-enabled `RiText.defaultAlignment`
- Added `RiText.prototype.color()` as used in `www/examples/canvas/simplest.html`
- Added `RiText.showBoundingBox()` setting a valule in `RiText.defaults`
- Catch undefined when trimming whitespace in `RiGrammar.prototype._expandRule()`

`/www/examples/...`:
- simplest (added `RiText.prototype.color()` to `rita.js` as noted above)
- grammar-haiku (both canvas and processing versions needed fixing)
- alignments (canvas version making Processing calls; invalid call to
  `showBoundingBoxes()`)
- typewriter (processing needed .wav path adjusted, canvas had a few bad
  function calls)
- move-to (canvas had `e.getType()` instead of `e.type()`)
- fade-to-text (same as move-to above)
- words-letters-lines (canvas had bad call to `showBoundingBoxes()`)

TODO:
- canvas version of words-letters-lines gets caught in `_getMetrics()` no-cache loop
- canvas version of create-lines does the same; including Processing to use `PFont` causes lack of `RiText.renderer` assignment of context
