### PR TITLE
Fixing .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-dist
+dist/
 **/web-export/*
 .javascript.liclipseprefs
-node_modules
+node_modules/
 **/node_modules/*
 .git
 config


### PR DESCRIPTION
There was an error in 8c924b198378bbfecea0c56585ac852c538daec3 -- looks like the intent was to add the `dist/` directory to the gitignore but it got added as `dist` (which only ignores files called "dist" but not directories). There is a similar error on `node_modules/` but it didn't matter because the recursive `**node_modules/` patten caught the base case anyway. This is causing the build issues in #40 and will resolve that question since we won't be committing `dist/` anymore.
