### PR TITLE
added UrlLoading-tests to gulp test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -307,7 +307,8 @@ gulp.task('test', function(cb) {
             'test/RiTa-tests',
             'test/RiGrammar-tests',
             'test/RiMarkov-tests',
-            'test/RiLexicon-tests'
+            'test/RiLexicon-tests',
+            'test/UrlLoading-tests'
         ];
 
         if (argv.name) {

--- a/test/UrlLoading-tests.js
+++ b/test/UrlLoading-tests.js
@@ -8,6 +8,7 @@ var runtests = function() {
 
     QUnit.module("UrlLoading", {
         setup : function() {
+            RiTa.SILENT = true;
         },
         teardown : function() {
         }
@@ -109,7 +110,7 @@ var runtests = function() {
         var id = setInterval(function() {
 
             if (rg1.ready()) {
-
+                
                 ok(rg1);
                 deepEqual(rg1, rg2);
                 deepEqual(rg1, rg3);
@@ -172,7 +173,7 @@ var runtests = function() {
         var id = setInterval(function() {
 
             if (rg1.ready()) {
-                rg1.print();
+                
                 ok(rg1);
                 deepEqual(rg1, rg2);
                 deepEqual(rg1, rg3);

--- a/test/UrlLoading-tests.js
+++ b/test/UrlLoading-tests.js
@@ -2,6 +2,9 @@
     QUnit, RiTa, RiTaEvent, RiString, RiGrammar, RiMarkov, RiLexicon */
 
 var runtests = function() {
+    
+    var filePath = (typeof module != 'undefined' && module.exports) ? 
+    "./test/data/" : "./data/";
 
     QUnit.module("UrlLoading", {
         setup : function() {
@@ -12,7 +15,7 @@ var runtests = function() {
 
     asyncTest("RiTa.loadString1(file)", function() {
 
-        RiTa.loadString("./data/sentence1.json", function(s) {
+        RiTa.loadString(filePath + "sentence1.json", function(s) {
             ok(s && s.length > 100);
             //console.log(s);
             ok(JSON.parse(s));
@@ -22,7 +25,7 @@ var runtests = function() {
 
     asyncTest("RiTa.loadString2(file)", function() {
 
-        RiTa.loadString("./data/sentence2.json", function(s) {
+        RiTa.loadString(filePath + "sentence2.json", function(s) {
             ok(s && s.length > 100);
             ok(JSON.parse(s));
             start();
@@ -97,7 +100,7 @@ var runtests = function() {
     asyncTest("RiGrammar.loadFrom(file)", function() {
 
         var rg1 = new RiGrammar();
-        rg1.loadFrom("./data/sentence1.json");
+        rg1.loadFrom(filePath + "sentence1.json");
 
         var rg2 = RiGrammar(JSON.stringify(sentenceGrammar));
         var rg3 = RiGrammar(JSON.stringify(sentenceGrammar2));
@@ -129,7 +132,7 @@ var runtests = function() {
     asyncTest("RiGrammar.loadFrom2(file)", function() {
 
         var rg1 = new RiGrammar();
-        rg1.loadFrom("./data/sentence2.json");
+        rg1.loadFrom(filePath + "sentence2.json");
         var rg2 = RiGrammar(JSON.stringify(sentenceGrammar));
         var rg3 = RiGrammar(JSON.stringify(sentenceGrammar2));
 
@@ -160,7 +163,7 @@ var runtests = function() {
     asyncTest("RiGrammar.loadFrom3(file)", function() {
 
         var rg1 = new RiGrammar();
-        rg1.loadFrom("./data/sentence1.yaml");
+        rg1.loadFrom(filePath + "sentence1.yaml");
         
         var rg2 = RiGrammar(JSON.stringify(sentenceGrammar));
         var rg3 = RiGrammar(JSON.stringify(sentenceGrammar2));
@@ -192,7 +195,7 @@ var runtests = function() {
     asyncTest("RiGrammar.loadFrom4(file)", function() {
 
         var rg1 = new RiGrammar();
-        rg1.loadFrom("./data/sentence2.yaml");
+        rg1.loadFrom(filePath + "sentence2.yaml");
         var rg2 = RiGrammar(JSON.stringify(sentenceGrammar));
         var rg3 = RiGrammar(JSON.stringify(sentenceGrammar2));
 
@@ -261,7 +264,7 @@ var runtests = function() {
     asyncTest("RiMarkov.loadFromFile", function() {
 
         var rm = new RiMarkov(3);
-        rm.loadFrom("./data/kafka.txt");
+        rm.loadFrom(filePath + "kafka.txt");
 
         var ts = +new Date();
         var id = setInterval(function() {
@@ -335,7 +338,7 @@ var runtests = function() {
      asyncTest("RiMarkov.loadFromFileMulti", function() {
 
      var rm = new RiMarkov(3);
-     rm.loadFrom(["./data/kafka.txt", "./data/wittgenstein.txt"]);
+     rm.loadFrom([filePath + "kafka.txt", filePath + "wittgenstein.txt"]);
 
      var ts = +new Date();
      var id = setInterval(function() {
@@ -368,7 +371,7 @@ var runtests = function() {
      });
      });
      asyncTest("RiTa.loadStringMulti(file)", function() { // TODO: why occasionally fails?!
-     RiTa.loadString(["./data/sentence1.json","./data/sentence2.json"], function(s) {
+     RiTa.loadString([filePath + "sentence1.json",filePath + "sentence2.json"], function(s) {
      ok(s && s.length>500);
      start();
      });


### PR DESCRIPTION
During gulp test in this commit, I've seen some console msgs from the RiGrammar part of the UrlLoading-tests. (The msgs also appear in the Web Browser Console when running the test from a web browser)
![screen shot 2015-06-25 at 4 38 28 am](https://cloud.githubusercontent.com/assets/2461812/8341000/cbc1bc56-1af4-11e5-8551-da406aa9e3f9.png)

Do you think we should also get rid of this?
